### PR TITLE
Add CI to test the template

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -1,0 +1,45 @@
+name: Build npm release
+
+trigger:
+  - master
+
+jobs:
+  - template: .ci/build-platform.yml
+    parameters:
+      platform: Linux
+      vmImage: ubuntu-16.04
+      STAGING_DIRECTORY: /home/vsts/STAGING
+      STAGING_DIRECTORY_UNIX: /home/vsts/STAGING
+      ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
+      ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
+
+  - template: .ci/build-platform.yml
+    parameters:
+      platform: macOS
+      vmImage: macOS-10.13
+      STAGING_DIRECTORY: /Users/vsts/STAGING
+      STAGING_DIRECTORY_UNIX: /Users/vsts/STAGING
+      ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i
+      ESY__CACHE_SOURCE_TARBALL_PATH: /Users/vsts/.esy/source/i
+
+  - template: .ci/build-platform.yml
+    parameters:
+      platform: Windows
+      vmImage: vs2017-win2016
+      STAGING_DIRECTORY: C:\Users\VssAdministrator\STAGING
+      STAGING_DIRECTORY_UNIX: /C/Users/VssAdministrator/STAGING
+      ESY__CACHE_INSTALL_PATH: /C/Users/VssAdministrator/.esy/3_/i
+      ESY__CACHE_SOURCE_TARBALL_PATH: /C/Users/VssAdministrator/.esy/source/i
+
+  # This job is kept here as we want to have the platform names in the same file
+  - job: Release
+    displayName: Release
+    dependsOn:
+      - Linux
+      - macOS
+      - Windows
+    pool:
+      vmImage: macOS-10.13
+      demands: node.js
+    steps:
+      - template: .ci/cross-release.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,8 @@ stages:
     steps:
       - template: .ci/utils/use-node.yml
       - template: .ci/utils/use-esy.yml
+      - script: "npm install -g pesy@next"
+        displayName: "install pesy"
       - script: mkdir $(Pipeline.Workspace)/hello-reason
         displayName: "Create project folder"
       - script: "pesy --template=esy/pesy-reason-template#$(Build.SourceBranchName)"
@@ -31,6 +33,8 @@ stages:
     steps:
       - template: .ci/utils/use-node.yml
       - template: .ci/utils/use-esy.yml
+      - script: "npm install -g pesy@next"
+        displayName: "install pesy"
       - script: mkdir $(Pipeline.Workspace)/hello-reason
         displayName: "Create project folder"
       - script: "pesy --template=esy/pesy-reason-template#$(Build.SourceBranchName)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,45 +1,58 @@
-name: Build npm release
+name: Build template
 
 trigger:
   - master
+pr:
+  branches:
+    include:
+    - '*'
 
-jobs:
-  - template: .ci/build-platform.yml
-    parameters:
-      platform: Linux
-      vmImage: ubuntu-16.04
-      STAGING_DIRECTORY: /home/vsts/STAGING
-      STAGING_DIRECTORY_UNIX: /home/vsts/STAGING
-      ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
-      ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
-
-  - template: .ci/build-platform.yml
-    parameters:
-      platform: macOS
-      vmImage: macOS-10.13
-      STAGING_DIRECTORY: /Users/vsts/STAGING
-      STAGING_DIRECTORY_UNIX: /Users/vsts/STAGING
-      ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i
-      ESY__CACHE_SOURCE_TARBALL_PATH: /Users/vsts/.esy/source/i
-
-  - template: .ci/build-platform.yml
-    parameters:
-      platform: Windows
-      vmImage: vs2017-win2016
-      STAGING_DIRECTORY: C:\Users\VssAdministrator\STAGING
-      STAGING_DIRECTORY_UNIX: /C/Users/VssAdministrator/STAGING
-      ESY__CACHE_INSTALL_PATH: /C/Users/VssAdministrator/.esy/3_/i
-      ESY__CACHE_SOURCE_TARBALL_PATH: /C/Users/VssAdministrator/.esy/source/i
-
-  # This job is kept here as we want to have the platform names in the same file
-  - job: Release
-    displayName: Release
-    dependsOn:
-      - Linux
-      - macOS
-      - Windows
+stages:
+- stage: Build
+  jobs:
+  - job: Linux
     pool:
-      vmImage: macOS-10.13
-      demands: node.js
+      vmImage: ubuntu-latest
     steps:
-      - template: .ci/cross-release.yml
+      - template: .ci/utils/use-node.yml
+      - template: .ci/utils/use-esy.yml
+      - script: mkdir $(Pipeline.Workspace)/hello-reason
+        displayName: "Create project folder"
+      - script: "pesy --template=esy/pesy-reason-template#$(Build.SourceBranchName)"
+        displayName: "Initialize pesy template"
+        workingDirectory: $(Pipeline.Workspace)/hello-reason
+      - script: "esy test"
+        displayName: "Run tests"
+        workingDirectory: $(Pipeline.Workspace)/hello-reason
+
+  - job: macOS
+    pool:
+      vmImage: macOS-latest
+    steps:
+      - template: .ci/utils/use-node.yml
+      - template: .ci/utils/use-esy.yml
+      - script: mkdir $(Pipeline.Workspace)/hello-reason
+        displayName: "Create project folder"
+      - script: "pesy --template=esy/pesy-reason-template#$(Build.SourceBranchName)"
+        displayName: "Initialize pesy template"
+        workingDirectory: $(Pipeline.Workspace)/hello-reason
+      - script: "esy test"
+        displayName: "Run tests"
+        workingDirectory: $(Pipeline.Workspace)/hello-reason
+  
+  - job: Windows
+    pool:
+      vmImage: windows-latest
+    steps:
+      - template: .ci/utils/use-node.yml
+      - template: .ci/utils/use-esy.yml
+      - script: "npm install -g pesy@next"
+        displayName: "install pesy"
+      - script: mkdir $(Pipeline.Workspace)/hello-reason
+        displayName: "Create project folder"
+      - script: "pesy --template=esy/pesy-reason-template#$(Build.SourceBranchName)"
+        displayName: "Initialize pesy template"
+        workingDirectory: $(Pipeline.Workspace)/hello-reason
+      - script: "esy test"
+        displayName: "Run tests"
+        workingDirectory: $(Pipeline.Workspace)/hello-reason


### PR DESCRIPTION
Renaming the current `azure-piplines.yml` to `azure-pipelines-template.yml` and creating a new `azure-pipelines.yml` to test the template.

It will install `esy` and `pesy` and then test the template with the current branch.

When we have a `eject` command we can also start packaging up the folder so that we can push it to git.