### PR TITLE
CI: Switch to macOS-latest

### DIFF
--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -1,6 +1,6 @@
 parameters:
   platform: "macOS"
-  vmImage: "macOS-10.13"
+  vmImage: "macOS-latest"
   STAGING_DIRECTORY: /Users/vsts/STAGING
   STAGING_DIRECTORY_UNIX: /Users/vsts/STAGING
   ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -16,7 +16,7 @@ jobs:
   - template: .ci/build-platform.yml
     parameters:
       platform: macOS
-      vmImage: macOS-10.13
+      vmImage: macOS-10.14
       STAGING_DIRECTORY: /Users/vsts/STAGING
       STAGING_DIRECTORY_UNIX: /Users/vsts/STAGING
       ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -16,7 +16,7 @@ jobs:
   - template: .ci/build-platform.yml
     parameters:
       platform: macOS
-      vmImage: macOS-10.14
+      vmImage: macOS-latest
       STAGING_DIRECTORY: /Users/vsts/STAGING
       STAGING_DIRECTORY_UNIX: /Users/vsts/STAGING
       ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i
@@ -39,7 +39,7 @@ jobs:
       - macOS
       - Windows
     pool:
-      vmImage: macOS-10.13
+      vmImage: macOS-latest
       demands: node.js
     steps:
       - template: .ci/cross-release.yml


### PR DESCRIPTION
`macOS-10.13` won't be supported anymore as of March 23 2020.

See: https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/

